### PR TITLE
using flamegraph in pvdkg benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,8 @@ version = "0.9.0"
 features = ["alloc"]
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "=0.3.4"
+pprof = { version = "0.4", features = ["flamegraph", "criterion"] }
 
 # local override for bls12-381
 #[patch.crates-io]
@@ -86,6 +87,11 @@ debug = true
 #harness = false
 #debug = false
 
+#[[bench]]
+#name = "bench_main"
+#harness = false
+
 [[bench]]
-name = "bench_main"
+name = "pvdkg"
+path = "benches/benchmarks/pvdkg.rs"
 harness = false

--- a/benches/benchmarks/pvdkg.rs
+++ b/benches/benchmarks/pvdkg.rs
@@ -27,8 +27,15 @@ pub fn dkgs(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, dkgs);
-criterion_main!(benches);
+use pprof::criterion::{Output, PProfProfiler};
+
+criterion_group!{
+    name = pvdkg_bls;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = dkgs
+}
+
+criterion_main!(pvdkg_bls);
 
 pub fn pvdkg<E: ark_ec::PairingEngine>() {
     use ark_ec::{AffineCurve, ProjectiveCurve};


### PR DESCRIPTION
based on https://github.com/tikv/pprof-rs/blob/v0.4.2/examples/criterion.rs
