### PR TITLE
Simplify validator sets in dkg state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,15 +35,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anomaly"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550632e31568ae1a5f47998c3aa48563030fc49b9ec91913ca337cf64fbc5ccb"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,17 +184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "async-trait"
-version = "0.1.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
@@ -357,12 +337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "bytes"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
-
-[[package]]
 name = "cast"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,20 +366,6 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "serde",
- "time",
- "winapi",
 ]
 
 [[package]]
@@ -672,7 +632,6 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "subtle",
- "tendermint",
  "zeroize",
 ]
 
@@ -691,107 +650,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.0.1"
+name = "findshlibs"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
 dependencies = [
- "matches",
- "percent-encoding",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
-dependencies = [
- "autocfg",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
-
-[[package]]
-name = "futures-task"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
-
-[[package]]
-name = "futures-util"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
-dependencies = [
- "autocfg",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
- "slab",
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -895,17 +762,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "idna"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,9 +836,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.102"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "lock_api"
@@ -1003,16 +859,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
 name = "measure_time"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68c8a1703dd54ab3307c03401e8b6c42121b67501dd6c6deb5077914ccb8085"
+checksum = "5f07966480d8562b3622f51df0b4e3fe6ea7ddb3b48b19b0f44ef863c455bdf9"
 dependencies = [
  "log",
 ]
@@ -1072,9 +922,9 @@ checksum = "94c7128ba23c81f6471141b90f17654f89ef44a56e14b8a4dd0fddfccd655277"
 
 [[package]]
 name = "nix"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8e5e343312e7fbeb2a52139114e9e702991ef9c2aea6817ff2440b35647d56"
+checksum = "f305c2c2e4c39a82f7bf0bf65fb557f9070ce06781d4f2454295cc34b1c43188"
 dependencies = [
  "bitflags",
  "cc",
@@ -1121,17 +971,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1255,12 +1094,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
-name = "percent-encoding"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
 name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,18 +1101,6 @@ checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
@@ -1311,12 +1132,14 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9fb4eee2f2c4f7d48fe5a33008dececbc405d0e58d2a94afe742d4f175bc401"
+checksum = "9d47237f290398d4cfcd293fcc9dcc53cdb1f9bde65b78fcbfaafa7f8190d9e9"
 dependencies = [
  "backtrace",
+ "cfg-if",
  "criterion",
+ "findshlibs",
  "inferno",
  "lazy_static",
  "libc",
@@ -1344,57 +1167,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "prost"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
-dependencies = [
- "bytes",
- "prost",
 ]
 
 [[package]]
@@ -1689,17 +1467,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,12 +1484,6 @@ name = "signature"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
-
-[[package]]
-name = "slab"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "smallvec"
@@ -1747,15 +1508,6 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
-name = "subtle-encoding"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
-dependencies = [
- "zeroize",
-]
 
 [[package]]
 name = "symbolic-common"
@@ -1818,55 +1570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tendermint"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/lowercase-node-id#ca0bffdde9a3f1597aea3e0faf518de453b72518"
-dependencies = [
- "anomaly",
- "async-trait",
- "bytes",
- "chrono",
- "ed25519",
- "ed25519-dalek",
- "futures",
- "num-traits",
- "once_cell",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "serde_json",
- "serde_repr",
- "sha2",
- "signature",
- "subtle",
- "subtle-encoding",
- "tendermint-proto",
- "thiserror",
- "toml",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "tendermint-proto"
-version = "0.20.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/lowercase-node-id#ca0bffdde9a3f1597aea3e0faf518de453b72518"
-dependencies = [
- "anomaly",
- "bytes",
- "chrono",
- "num-derive",
- "num-traits",
- "prost",
- "prost-types",
- "serde",
- "serde_bytes",
- "subtle-encoding",
- "thiserror",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,16 +1599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,21 +1607,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5241dd6f21443a3606b432718b166d3cedc962fd4b8bea54a8bc7f514ebda986"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
@@ -1952,21 +1630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,18 +1640,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "url"
-version = "2.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
-dependencies = [
- "form_urlencoded",
- "idna",
- "matches",
- "percent-encoding",
-]
 
 [[package]]
 name = "uuid"

--- a/ferveo-common/src/lib.rs
+++ b/ferveo-common/src/lib.rs
@@ -15,8 +15,6 @@ impl Rng for ark_std::rand::prelude::StdRng {}
 
 pub trait Rng: ark_std::rand::CryptoRng + ark_std::rand::RngCore {}
 
-use serde::{Deserialize, Serialize};
-
 pub mod ark_serde {
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
     use serde_bytes::{Deserialize, Serialize};
@@ -46,6 +44,7 @@ pub mod ark_serde {
 
 #[test]
 fn test_ark_serde() {
+    use serde::{Serialize, Deserialize};
     use ark_bls12_381::G1Affine;
     #[derive(Serialize, Deserialize)]
     struct Test {

--- a/ferveo/Cargo.toml
+++ b/ferveo/Cargo.toml
@@ -45,12 +45,10 @@ serde_json = "1.0"
 borsh = "0.9"
 subtle = "2.4"
 itertools = "0.10.1"
-measure_time = "0.7"
+measure_time = "0.8"
 #redjubjub = "0.4.0"
 ark-ed-on-bls12-381 = "0.3.0"
 group-threshold-cryptography = { path = "../tpke" }
-#tendermint = { path = "../../tendermint-rs/tendermint" }
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "tomas/lowercase-node-id"}
 ferveo-common = { path = "../ferveo-common" }
 
 [dependencies.digest]
@@ -59,7 +57,7 @@ features = ["alloc"]
 
 [dev-dependencies]
 criterion = "0.3"
-pprof = { version = "0.5", features = ["flamegraph", "criterion"] }
+pprof = { version = "0.6", features = ["flamegraph", "criterion"] }
 
 # local override for bls12-381
 #[patch.crates-io]

--- a/ferveo/benches/benchmarks/pvdkg.rs
+++ b/ferveo/benches/benchmarks/pvdkg.rs
@@ -37,17 +37,8 @@ criterion_group! {
 
 criterion_main!(pvdkg_bls);
 
-fn create_info(vp: u64) -> tendermint::validator::Info {
-    use std::convert::TryFrom;
-    tendermint::validator::Info::new(
-        tendermint::public_key::PublicKey::from_raw_ed25519(&vec![
-            48, 163, 55, 132, 231, 147, 230, 163, 56, 158, 127, 218, 179, 139,
-            212, 103, 218, 89, 122, 126, 229, 88, 84, 48, 32, 0, 185, 174, 63,
-            72, 203, 52,
-        ])
-        .unwrap(),
-        tendermint::vote::Power::try_from(vp).unwrap(),
-    )
+fn create_info(vp: u64) -> TendermintValidator {
+    TendermintValidator { power: vp }
 }
 
 pub fn pvdkg<E: ark_ec::PairingEngine>() {
@@ -61,9 +52,11 @@ pub fn pvdkg<E: ark_ec::PairingEngine>() {
         security_threshold: 300 / 3,
         total_weight: 300,
     };
-    let validator_set = tendermint::validator::Set::without_proposer(
-        (1..11u64).map(|vp| create_info(vp)).collect::<Vec<_>>(),
-    );
+    let validator_set = ValidatorSet {
+        validators: (1..11u64)
+            .map(|vp| TendermintValidator { power: vp })
+            .collect::<Vec<_>>(),
+    };
 
     let validator_keys = (0..10)
         .map(|_| {
@@ -76,7 +69,7 @@ pub fn pvdkg<E: ark_ec::PairingEngine>() {
     for me in 0..10 {
         contexts.push(
             PubliclyVerifiableDkg::<ark_bls12_381::Bls12_381>::new(
-                &validator_set,
+                validator_set.clone(),
                 &validator_keys,
                 params.clone(),
                 me,

--- a/ferveo/examples/pvdkg.rs
+++ b/ferveo/examples/pvdkg.rs
@@ -5,17 +5,8 @@ pub fn main() {
     pvdkg::<ark_bls12_381::Bls12_381>();
 }
 
-fn create_info(vp: u64) -> tendermint::validator::Info {
-    use std::convert::TryFrom;
-    tendermint::validator::Info::new(
-        tendermint::public_key::PublicKey::from_raw_ed25519(&vec![
-            48, 163, 55, 132, 231, 147, 230, 163, 56, 158, 127, 218, 179, 139,
-            212, 103, 218, 89, 122, 126, 229, 88, 84, 48, 32, 0, 185, 174, 63,
-            72, 203, 52,
-        ])
-        .unwrap(),
-        tendermint::vote::Power::try_from(vp).unwrap(),
-    )
+fn create_info(vp: u64) -> TendermintValidator {
+    TendermintValidator { power: vp }
 }
 
 pub fn pvdkg<E: ark_ec::PairingEngine>() {
@@ -30,7 +21,9 @@ pub fn pvdkg<E: ark_ec::PairingEngine>() {
         total_weight: 300,
     };
     let validator_set = ValidatorSet {
-        validators: (1..11u64).map(|vp| TendermintValidator { power: vp }).collect::<Vec<_>>(),
+        validators: (1..11u64)
+            .map(|vp| TendermintValidator { power: vp })
+            .collect::<Vec<_>>(),
     };
 
     let validator_keys = (0..10)

--- a/ferveo/examples/pvdkg.rs
+++ b/ferveo/examples/pvdkg.rs
@@ -1,4 +1,5 @@
 use ferveo::*;
+use ferveo_common::Validator;
 
 pub fn main() {
     pvdkg::<ark_bls12_381::Bls12_381>();
@@ -28,9 +29,9 @@ pub fn pvdkg<E: ark_ec::PairingEngine>() {
         security_threshold: 300 / 3,
         total_weight: 300,
     };
-    let validator_set = tendermint::validator::Set::without_proposer(
-        (1..11u64).map(|vp| create_info(vp)).collect::<Vec<_>>(),
-    );
+    let validator_set = ValidatorSet {
+        validators: (1..11u64).map(|vp| TendermintValidator { power: vp }).collect::<Vec<_>>(),
+    };
 
     let validator_keys = (0..10)
         .map(|_| {
@@ -43,7 +44,7 @@ pub fn pvdkg<E: ark_ec::PairingEngine>() {
     for me in 0..10 {
         contexts.push(
             PubliclyVerifiableDkg::<ark_bls12_381::Bls12_381>::new(
-                &validator_set,
+                validator_set.clone(),
                 &validator_keys,
                 params.clone(),
                 me,

--- a/ferveo/src/dkg/common.rs
+++ b/ferveo/src/dkg/common.rs
@@ -13,20 +13,19 @@ use itertools::izip;
 /// partition_domain returns a vector of DKG participants
 pub fn partition_domain<E: PairingEngine>(
     params: &Params,
-    validator_set: &tendermint::validator::Set,
+    validator_set: &ValidatorSet,
     validator_keys: &[ferveo_common::PublicKey<E>],
 ) -> Result<Vec<ferveo_common::Validator<E>>> {
-    let validators = validator_set.validators();
     // Sort participants from greatest to least stake
 
     // Compute the total amount staked
     let total_voting_power = params.total_weight as f64
-        / validator_set.total_voting_power().value() as f64;
+        / validator_set.total_voting_power() as f64;
 
     // Compute the weight of each participant rounded down
-    let mut weights = validators
+    let mut weights = validator_set.validators
         .iter()
-        .map(|p| (p.power() as f64 * total_voting_power).floor() as u32)
+        .map(|p| (p.power as f64 * total_voting_power).floor() as u32)
         .collect::<Vec<_>>();
 
     // Add any excess weight to the largest weight participants
@@ -44,8 +43,8 @@ pub fn partition_domain<E: PairingEngine>(
 
     let mut allocated_weight = 0usize;
     let mut participants = vec![];
-    for (validator, weight, key) in
-        izip!(validators.iter(), weights.iter(), validator_keys.iter())
+    for (_, weight, key) in
+        izip!(validator_set.validators.iter(), weights.iter(), validator_keys.iter())
     {
         participants.push(ferveo_common::Validator::<E> {
             key: *key,


### PR DESCRIPTION
We no longer pass in tendermint validator info (which contains lots of extraneous data) but instead use custom types that only use necessary data